### PR TITLE
Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ENV/
 
 staticfiles/**
 !staticfiles/.gitkeep
+cover

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -60,13 +60,15 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose',
 ]
 
-# NOSE_ARGS = [
-#     '--with-coverage',
-#     # Specify which apps to cover
-#     '--cover-package=resources,feedback',
-# ]
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=resources,feedback',
+]
 
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -63,7 +63,8 @@ INSTALLED_APPS = [
     'django_nose',
 ]
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+if not (os.environ.get('TRAVIS')):
+    TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 NOSE_ARGS = [
     '--with-coverage',


### PR DESCRIPTION
Ref #99 
Add coverage to the project, this can be run locally with:
```bash
python manage.py test --with-coverage
```
The report can be generated with:
```bash
python manage.py test --with-coverage --cover-html
```