### PR TITLE
Deploy fixes

### DIFF
--- a/cms/settings/base.py
+++ b/cms/settings/base.py
@@ -119,6 +119,8 @@ DATABASES['default'] = dj_database_url.config(default='postgres://127.0.0.1:5432
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 ALLOWED_HOSTS = [
+    'londonminds.co.uk',
+    'www.londonminds.co.uk',
     'ldmw.herokuapp.com',
     'ldmw-staging.herokuapp.com',
     'ldmw-cms.herokuapp.com',

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Content Management System for LDMW",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm run install:elm && npm run install:pip",
+    "postinstall": "npm run install:elm",
     "install:elm": "node_modules/.bin/elm-make ./cms/elm/Main.elm --output=./cms/static/js/elm.js --yes",
-    "install:pip": "pip3 install -r requirements.txt",
     "test": "TRAVIS=true python3 manage.py test",
     "lint": "flake8 . --exclude=migrations,cms/settings",
     "cover": "python3 manage.py test"


### PR DESCRIPTION
* Adds londonminds to allowed hosts
* removes pip install from package json: python is sometimes not installed before node so build errors