### PR TITLE
Disqus

### DIFF
--- a/resources/templates/resources/disqus.html
+++ b/resources/templates/resources/disqus.html
@@ -1,12 +1,13 @@
 <div id="disqus_thread" class="bt pa2 br1 shadow-2 tl w-60-ns center"></div>
 <script>
 var disqus_config = function () {
+  this.page.url = 'http://londonminds.co.uk/';
   this.page.identifier = 'resource{{page.id}}';
   this.page.title = '{{page.heading}}';
 };
 (function() { // DON'T EDIT BELOW THIS LINE
 var d = document, s = d.createElement('script');
-s.src = 'https://londonminds-co-uk.disqus.com/embed.js';
+s.src = 'https://newsite-6.disqus.com/embed.js';
 s.setAttribute('data-timestamp', +new Date());
 (d.head || d.body).appendChild(s);
 })();


### PR DESCRIPTION
The previous url was removed at some point. This new one has been set up in the `disqus` admin page.

Ref #178 

The only way to test that this is working though is to actually have it deployed to the `londonminds.co.uk` site 🤔 