### PR TITLE
ignores query string when fetching template

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 
 
 def landing_page_controller(request, **kwargs):
-    split_path = request.get_full_path().split('/')
+    split_path = request.get_full_path().split('?')[0].split('/')
 
     path = '-'.join(filter(lambda e: e != '', split_path))
 


### PR DESCRIPTION
ref #243, I was mapping the request path to the template but didn't take into account that ad links would be using a query string