### PR TITLE
Disqus

### DIFF
--- a/resources/templates/resources/disqus.html
+++ b/resources/templates/resources/disqus.html
@@ -1,7 +1,7 @@
 <div id="disqus_thread" class="bt pa2 br1 shadow-2 tl w-60-ns center"></div>
 <script>
 var disqus_config = function () {
-  this.page.url = 'http://londonminds.co.uk/';
+  this.page.url = 'http://londonminds.co.uk/resources/{{page.slug}}';
   this.page.identifier = 'resource{{page.id}}';
   this.page.title = '{{page.heading}}';
 };


### PR DESCRIPTION
Ref #178 

It seems that you should also configure a unique url for the comments to not display on multiple pages, hopefully this fixes this: https://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages-