### PR TITLE
Change 2 miles to 1 mile

### DIFF
--- a/resources/models/resources.py
+++ b/resources/models/resources.py
@@ -291,7 +291,7 @@ class ResourcePage(Page):
                     float(latitude), float(longitude),
                     float(self.latitude), float(self.longitude)
                 )
-                context['is_near'] = dist_km / 1.6 < 2000  # less than 2 miles
+                context['is_near'] = dist_km / 1.6 < 1000  # less than 1 mile
             except:
                 print("Failed to get location")
                 context['is_near'] = False


### PR DESCRIPTION
Previous setup showed the badge for resources within 2 miles, should be 1 mile as specified on #302 