### PR TITLE
Site Title

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -30,15 +30,9 @@
         <title>
             {% block title %}
                 {% if self.seo_title %}
-                    Good Thinking
-                    {% if self.seo_title != "Home" %}
-                        | {{ self.seo_title }}
-                    {% endif %}
+                  {{ self.seo_title }} | {{self.get_site.site_name}}
                 {% else %}
-                    London Minds
-                    {% if self.title != "Home" %}
-                        | {{ self.title }}
-                    {% endif %}
+                  {{self.get_site.site_name}}
                 {% endif %}
             {% endblock %}
         </title>


### PR DESCRIPTION
ref #506 
Page title is now {title of page} | {site title} when a page has an seo title, or just {site title} when it doesn't.
Site title is defined in Wagtail in Settings -> Sites.