### PR TITLE
removes arrow function

### DIFF
--- a/cms/static/js/personalise.js
+++ b/cms/static/js/personalise.js
@@ -75,7 +75,7 @@ if (personaliseDiv) {
       feedbackLoopListener();
       swipeListeners();
       analyticsListeners();
-      selectAll('.tip-card-contain').forEach(el => {
+      selectAll('.tip-card-contain').forEach(function(el) {
         el.style.height = tipHeight + "px"
       });
       mobileProsAndCons();


### PR DESCRIPTION
Yuglify was throwing an error when trying to minify the js, because there was an arrow function, which it doesn't support