### PR TITLE
Fix chevron scroll on IOS chrome

### DIFF
--- a/cms/static/css/cms.css
+++ b/cms/static/css/cms.css
@@ -222,6 +222,10 @@ code {
   width: 0.5rem;
 }
 
+.mw-80 {
+  max-width: 35em;
+}
+
 .h18 {
   height: 1.8rem;
 }

--- a/cms/static/js/smooth_scroll.js
+++ b/cms/static/js/smooth_scroll.js
@@ -5,7 +5,7 @@ function scrollToElement (e, elementId) {
   var element = select(elementId);
   var targetPos = element.offsetTop - element.offsetHeight;
 
-  window.scrollTo({
+  window.scroll({
     top: targetPos,
     left: 0,
     behavior: 'smooth'

--- a/static/templates/static/static_page.html
+++ b/static/templates/static/static_page.html
@@ -8,7 +8,7 @@
   {% include "resources/banner.html" %}
   {% include "resources/components/hamburger-menu.html" with page=page landing_pages=landing_pages %}
   <section class="pt5-plus ph4 ph5-m ph6-l tc">
-    <div class="{{ page.text_alignment }} copy static-page">
+    <div class="{{ page.text_alignment }} copy static-page mw-80 center">
       {% for block in page.body %}
         {% include_block block %}
       {% endfor %}


### PR DESCRIPTION
ScrollTo was causing IOS Chrome to scroll up instead of down. Scroll fixed so that it can scroll down instead. #559 

Sets max width to ~80 characters #641 