### PR TITLE
stops see more auto showing if no tips

### DIFF
--- a/cms/elm/View.elm
+++ b/cms/elm/View.elm
@@ -99,7 +99,7 @@ get_resources model =
         (\i el ->
             case model.show_more of
                 False ->
-                    if i < 2 || (List.length model.tips == 0) then
+                    if i < 2 then
                         Resources.view el ""
                     else if (rem (i + 1) 3) == 0 && (i < 3) then
                         div []


### PR DESCRIPTION
If there were no tips, all resources were showing above the 'show more resources' button. This fixes that.