### PR TITLE
adds ability to edit html in richtext fields

### DIFF
--- a/cms/static/css/wagtail.css
+++ b/cms/static/css/wagtail.css
@@ -3,3 +3,7 @@ li.rgb_color_field input {
   width: 100px!important;
   padding: 0px!important;
 }
+
+.hallohtml .ui-button-text i:before {
+  content:'</>';
+}

--- a/resources/wagtail_hooks.py
+++ b/resources/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.html import format_html
+from wagtail.wagtailcore.whitelist import attribute_rule, check_url
 
 from wagtail.wagtailcore import hooks
 
@@ -10,3 +11,22 @@ def editor_css():
         '<link rel="stylesheet" href="{}">',
         static('css/wagtail.css')
     )
+
+
+@hooks.register('insert_editor_js')
+def enable_source():
+    return format_html(
+        """
+        <script>
+            registerHalloPlugin('hallohtml');
+        </script>
+        """
+    )
+
+
+@hooks.register('construct_whitelister_element_rules')
+def whitelister_element_rules():
+    return {
+        'a': attribute_rule({'href': check_url, 'id': True, 'class': True}),
+        'button': attribute_rule({'id': True, 'class': True})
+    }


### PR DESCRIPTION
#685
Uses Hallojs plugin to allow html to be edited directly in richtext fields.
Whitelists buttons, classes and ids. 