### PR TITLE
Change server runner to use waitress

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT cms.wsgi:application
+web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT --threads=6 cms.wsgi:application

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && python manage.py runserver --settings cms.settings.production 0.0.0.0:$PORT
+web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT cms.wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT --threads=6 cms.wsgi:application
+web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT --threads=15 cms.wsgi:application

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT cms.wsgi
+web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT cms.wsgi:application

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT --threads=15 cms.wsgi:application
+web: python manage.py migrate && python manage.py collectstatic -c --no-input --settings cms.settings.production && waitress-serve --port=$PORT --threads=6 cms.wsgi:application

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ Unidecode==0.4.20
 urllib3==1.21.1
 uWSGI==2.0.15
 virtualenv==15.1.0
-waitress=1.1.0
+waitress==1.1.0
 wagtail==1.10.1
 wcwidth==0.1.7
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ Unidecode==0.4.20
 urllib3==1.21.1
 uWSGI==2.0.15
 virtualenv==15.1.0
+waitress=1.1.0
 wagtail==1.10.1
 wcwidth==0.1.7
 webencodings==0.5.1


### PR DESCRIPTION
Change Heroku server runner command from the regular `python` to `waitress` to improve ability to handle multiple web requests.  Initially changed to `gunicorn` but there is discussion out there that `gunicorn` finds it difficult to handle slow network clients, see http://blog.etianen.com/blog/2014/01/19/gunicorn-heroku-django/