### PR TITLE
allows upload of robots.txt file to wagtail

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -16,7 +16,7 @@ from resources.views import (
     assessment_controller, assessment_summary_controller
 )
 
-from django.views.generic import TemplateView
+from cms.views import robots_handler
 
 from wagtail.contrib.wagtailsitemaps.views import sitemap
 
@@ -38,10 +38,7 @@ urlpatterns = [
 
     url(
         r'^robots\.txt',
-        TemplateView.as_view(
-            template_name='robots.txt', content_type='text/plain'
-        ),
-        name="cms"
+        robots_handler
     ),
 
 

--- a/cms/views.py
+++ b/cms/views.py
@@ -1,0 +1,16 @@
+from django.template import Template, Context
+from django.shortcuts import get_object_or_404
+from django.http import HttpResponse
+
+from wagtail.wagtaildocs.models import Document
+
+
+def robots_handler(request):
+    document = get_object_or_404(Document, title="robots.txt")
+    content = document.file.read()
+    template = Template(content)
+
+    return HttpResponse(
+        template.render(Context({})),
+        content_type="text/plain"
+    )


### PR DESCRIPTION
ref #673, robots.txt can now be uploaded to the documents section of wagtail, and will then be served on the /robots.txt endpoint