### PR TITLE
E24 UI

### DIFF
--- a/cms/static/css/fonts.css
+++ b/cms/static/css/fonts.css
@@ -140,6 +140,11 @@ button, button a {
   margin-bottom: 0.3rem;
 }
 
+.e24subtext {
+  font-size: 12px !important;
+  font-style: italic;
+}
+
 @media screen and (max-width:30em) {
   h1 {
     font-size: 40px;

--- a/cms/static/css/fonts.css
+++ b/cms/static/css/fonts.css
@@ -54,7 +54,7 @@ h5 {
   line-height: 20px;
 }
 
-p, li {
+p, li :not(span ul li) {
   font-family: 'Montserrat', sans-serif;
   letter-spacing: 0.5pt;
   font-weight: 600;

--- a/resources/templates/resources/assessment/question-table.html
+++ b/resources/templates/resources/assessment/question-table.html
@@ -3,9 +3,9 @@
 {% with table.Questions|first as first_question %}
 
   {% for q in table.Questions %}
-    <h3>
+    <div class="mv3">
       {{q.DisplayText|new_tab|richtext}}
-    </h3>
+    </div>
     {% if q.Error %}
       <div class="bg--lm-light-red ba b--lm-dark-red bw1 br1 dib">
         {{q.Error}}

--- a/resources/templates/resources/assessment/server-assessment.html
+++ b/resources/templates/resources/assessment/server-assessment.html
@@ -78,13 +78,13 @@
           {% include "resources/assessment/question-table.html" with table=q %}
           {% endif %}
           {% for a in q.Answers %}
-          <div class="pv1">
+          <div class="pv1 dt">
             {% if a.ControlType == "text" %}
-            <input class="e24answers dib mr2" type="{{a.ControlType}}" id="{{a.ControlID}}" name="{{a.ControlID}}" value="{{a.ControlValue}}" />
+            <input class="e24answers dtc mr2" type="{{a.ControlType}}" id="{{a.ControlID}}" name="{{a.ControlID}}" value="{{a.ControlValue}}" />
             {% else %}
-            <input class="e24answers dib mr1" type="{{a.ControlType}}" id="{{a.ControlID}}" name="{{a.ControlName}}" value="{{a.ControlValue}}" {% if a.isChecked %}checked{% endif %} />
+            <input class="e24answers dtc mr1" type="{{a.ControlType}}" id="{{a.ControlID}}" name="{{a.ControlName}}" value="{{a.ControlValue}}" {% if a.isChecked %}checked{% endif %} />
             {% endif %}
-            <label for="{{a.ControlID}}" class="dib">
+            <label for="{{a.ControlID}}" class="dtc">
               {{a.DisplayText}}
             </label>
             {% if a.hasInfo %}

--- a/resources/templates/resources/assessment/server-assessment.html
+++ b/resources/templates/resources/assessment/server-assessment.html
@@ -131,18 +131,18 @@
       <input type="hidden" name="node_id" value="{{NodeID}}" />
       <div class="pv3 w-100 dt">
         <div class="w-50 tl dtc">
-          {% if not first_question %}
+          {% if not first_question and not suppressBack %}
             <button class="f6 f5-ns tl b--none bg-white fw6 lm-pink-hover lm-dark-turquoise pointer ph0" type="submit" name="previous" value="Previous">previous question</button>
           {% endif %}
         </div>
-        {% if not Conclusions %}
-        <div class="tr dtc">
-          {% if first_question %}
-            <button id="start-assessment" class="f6 f5-ns tr b--none bg-white fw6 lm-pink-hover lm-dark-turquoise pointer ph0" type="submit" name="next" value="Next">start assessment</button>
-          {% else %}
-            <button id="next-question" data-node-id="{{NodeID}}" class="f6 f5-ns tr b--none bg-white fw6 lm-pink-hover lm-dark-turquoise pointer ph0" type="submit" name="next" value="Next">next question</button>
-          {% endif %}
-        </div>
+        {% if not Conclusions and not suppressNext %}
+          <div class="tr dtc">
+            {% if first_question %}
+              <button id="start-assessment" class="f6 f5-ns tr b--none bg-white fw6 lm-pink-hover lm-dark-turquoise pointer ph0" type="submit" name="next" value="Next">start assessment</button>
+            {% else %}
+              <button id="next-question" data-node-id="{{NodeID}}" class="f6 f5-ns tr b--none bg-white fw6 lm-pink-hover lm-dark-turquoise pointer ph0" type="submit" name="next" value="Next">next question</button>
+            {% endif %}
+          </div>
         {% endif %}
       </div>
     </form>


### PR DESCRIPTION
`<span>`s now mirror styling for `.e24subtext` class. #767 
Back and next buttons are hidden when suppressBack or suppressNext are true respectively #773 
Display text always on same line as radio button/checkbox #770 
Display questions with bold only as is input #774 